### PR TITLE
Remove MUI dependency from React component (v2.0.0)

### DIFF
--- a/.github/workflows/reacttest.yml
+++ b/.github/workflows/reacttest.yml
@@ -28,5 +28,8 @@ jobs:
       working-directory: js/react
       run: npm run build-lib
     - name: Run Tests
-      working-directory: js/react/demo
-      run: npm run test -- --watchAll=false
+      working-directory: js/react
+      run: npm test
+    - name: Build demo
+      working-directory: js/react
+      run: npm run build-demo

--- a/js/react/package.json
+++ b/js/react/package.json
@@ -1,12 +1,19 @@
 {
   "name": "neural-activity-visualizer-react",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "A ReactJS component for visualizing neural activity data",
   "files": [
     "dist"
   ],
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.cjs.js"
+    },
+    "./style.css": "./dist/style.css"
+  },
   "type": "module",
   "scripts": {
     "prepublishOnly": "npm run build-lib",
@@ -30,10 +37,6 @@
     "directory": "js/react"
   },
   "devDependencies": {
-    "@emotion/react": "^11.13.3",
-    "@emotion/styled": "^11.13.0",
-    "@mui/icons-material": "^6.1.6",
-    "@mui/material": "^6.1.6",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.0.1",
     "@testing-library/user-event": "^14.5.2",
@@ -48,10 +51,6 @@
     "vitest": "^2.1.4"
   },
   "peerDependencies": {
-    "@emotion/react": "^11",
-    "@emotion/styled": "^11",
-    "@mui/icons-material": "^6",
-    "@mui/material": "^6",
     "plotly.js": "^2",
     "react": "^19",
     "react-dom": "^19",

--- a/js/react/src/ErrorPanel.js
+++ b/js/react/src/ErrorPanel.js
@@ -1,12 +1,11 @@
 import React from "react";
-import Alert from "@mui/material/Alert";
 
 export default function ErrorPanel(props) {
     if (props.message) {
         return (
-            <Alert sx={{ margin: 2 }} severity="error">
+            <div className="nv-alert nv-alert--error" role="alert">
                 {props.message}
-            </Alert>
+            </div>
         );
     } else {
         return "";

--- a/js/react/src/HeaderPanel.js
+++ b/js/react/src/HeaderPanel.js
@@ -1,49 +1,37 @@
 import React from "react";
 
-import Box from "@mui/material/Box";
-import InputLabel from "@mui/material/InputLabel";
-import MenuItem from "@mui/material/MenuItem";
-import FormControl from "@mui/material/FormControl";
-import Select from "@mui/material/Select";
-
-import ButtonGroup from "@mui/material/ButtonGroup";
-import Button from "@mui/material/Button";
-import TimelineIcon from "@mui/icons-material/Timeline";
-import ScatterPlotIcon from "@mui/icons-material/ScatterPlot";
-import Tooltip from "@mui/material/Tooltip";
-
-import IconButton from "@mui/material/IconButton";
-import InfoIcon from "@mui/icons-material/Info";
+import {
+    TimelineIcon,
+    ScatterPlotIcon,
+    InfoIcon,
+    GetAppIcon,
+} from "./icons";
 import InfoPanel from "./InfoPanel";
-import GetAppIcon from "@mui/icons-material/GetApp";
-
-import CircularProgress from "@mui/material/CircularProgress";
 
 function SegmentSelect(props) {
-    let menuItemAll = "";
+    let optionAll = null;
     if (props.consistent) {
-        menuItemAll = <MenuItem value={"all"}>All</MenuItem>;
+        optionAll = <option value="all">All</option>;
     }
     return (
-        <FormControl sx={{ margin: 1, minWidth: 120 }}>
-            <InputLabel id="select-segment-label">Segment</InputLabel>
-            <Select
-                labelId="select-segment-label"
+        <div className="nv-form-control">
+            <label className="nv-label" htmlFor="select-segment">
+                Segment
+            </label>
+            <select
+                className="nv-select"
                 id="select-segment"
                 value={props.labels[props.segmentId] ? props.segmentId : 0}
                 onChange={props.onChange}
-                label="Segment"
             >
-                {menuItemAll}
-                {props.labels.map((seg, index) => {
-                    return (
-                        <MenuItem key={index} value={index}>
-                            {seg.label}
-                        </MenuItem>
-                    );
-                })}
-            </Select>
-        </FormControl>
+                {optionAll}
+                {props.labels.map((seg, index) => (
+                    <option key={index} value={index}>
+                        {seg.label}
+                    </option>
+                ))}
+            </select>
+        </div>
     );
 }
 
@@ -56,26 +44,23 @@ function SignalSelect(props) {
     }
     if (props.show && props.labels[segmentId]) {
         return (
-            <FormControl sx={{ margin: 1, minWidth: 120 }}>
-                <InputLabel id="select-signal-label">Signal</InputLabel>
-                <Select
-                    labelId="select-signal-label"
+            <div className="nv-form-control">
+                <label className="nv-label" htmlFor="select-signal">
+                    Signal
+                </label>
+                <select
+                    className="nv-select"
                     id="select-signal"
                     value={props.signalId}
                     onChange={props.onChange}
-                    label="Signal"
                 >
-                    {props.labels[segmentId].signalLabels.map(
-                        (label, index) => {
-                            return (
-                                <MenuItem key={index} value={index}>
-                                    {label}
-                                </MenuItem>
-                            );
-                        }
-                    )}
-                </Select>
-            </FormControl>
+                    {props.labels[segmentId].signalLabels.map((label, index) => (
+                        <option key={index} value={index}>
+                            {label}
+                        </option>
+                    ))}
+                </select>
+            </div>
         );
     } else {
         return "";
@@ -84,19 +69,15 @@ function SignalSelect(props) {
 
 function LoadingAnimation(props) {
     if (props.loading) {
-        return (
-            <CircularProgress
-                sx={{ margin: 1, verticalAlign: "middle" }}
-                color="secondary"
-            />
-        );
+        return <span className="nv-spinner" aria-label="Loading" />;
     } else {
         return "";
     }
 }
 
 export default function HeaderPanel(props) {
-    const [popoverAnchor, setPopoverAnchor] = React.useState(null);
+    const infoContainerRef = React.useRef(null);
+    const [infoOpen, setInfoOpen] = React.useState(false);
 
     React.useEffect(() => {
         console.log(props);
@@ -139,50 +120,36 @@ export default function HeaderPanel(props) {
         }
     };
 
-    const handleShowInfo = (event) => {
-        setPopoverAnchor(event.currentTarget);
+    const handleShowInfo = () => {
+        setInfoOpen((prev) => !prev);
     };
 
     const handleHideInfo = () => {
-        setPopoverAnchor(null);
+        setInfoOpen(false);
     };
 
-    const infoOpen = Boolean(popoverAnchor);
-    const id = infoOpen ? "info-panel" : undefined;
     return (
-        <Box sx={{ margin: 2 }}>
+        <div className="nv-header">
             {!props.disableChoice && (
-                <ButtonGroup
-                    color="primary"
+                <div
+                    className="nv-button-group"
                     aria-label="outlined primary button group"
-                    sx={{ margin: 1, verticalAlign: "middle" }}
                 >
-                    <Tooltip
+                    <button
+                        className={`nv-button${props.showSignals ? " nv-button--active" : ""}`}
+                        onClick={() => handleChangeVisibility("signals")}
                         title={`${props.showSignals ? "Hide" : "Show"} signals`}
                     >
-                        <Button
-                            onClick={() => handleChangeVisibility("signals")}
-                            variant={`${props.showSignals ? "contained" : "outlined"
-                                }`}
-                        >
-                            <TimelineIcon />
-                        </Button>
-                    </Tooltip>
-                    <Tooltip
-                        title={`${props.showSpikeTrains ? "Hide" : "Show"
-                            } spiketrains`}
+                        <TimelineIcon />
+                    </button>
+                    <button
+                        className={`nv-button${props.showSpikeTrains ? " nv-button--active" : ""}`}
+                        onClick={() => handleChangeVisibility("spiketrains")}
+                        title={`${props.showSpikeTrains ? "Hide" : "Show"} spiketrains`}
                     >
-                        <Button
-                            onClick={() =>
-                                handleChangeVisibility("spiketrains")
-                            }
-                            variant={`${props.showSpikeTrains ? "contained" : "outlined"
-                                }`}
-                        >
-                            <ScatterPlotIcon />
-                        </Button>
-                    </Tooltip>
-                </ButtonGroup>
+                        <ScatterPlotIcon />
+                    </button>
+                </div>
             )}
             <SegmentSelect
                 segmentId={props.segmentId}
@@ -198,35 +165,35 @@ export default function HeaderPanel(props) {
                 show={props.showSignals}
             />
 
-            <Tooltip title="File metadata">
-                <IconButton
+            <div className="nv-info-container" ref={infoContainerRef}>
+                <button
+                    className="nv-icon-button"
                     onClick={handleShowInfo}
                     aria-label="info"
-                    sx={{ marginTop: 1, marginBottom: 1, verticalAlign: "middle" }}
+                    title="File metadata"
                 >
-                    <InfoIcon fontSize="medium" color="primary" />
-                </IconButton>
-            </Tooltip>
-            <InfoPanel
-                id={id}
-                source={props.source}
-                info={props.metadata}
-                open={infoOpen}
-                anchor={popoverAnchor}
-                onClose={handleHideInfo}
-            />
+                    <InfoIcon fontSize="medium" />
+                </button>
+                <InfoPanel
+                    id="info-panel"
+                    source={props.source}
+                    info={props.metadata}
+                    open={infoOpen}
+                    onClose={handleHideInfo}
+                    containerRef={infoContainerRef}
+                />
+            </div>
 
-            <Tooltip title="Download data file">
-                <IconButton
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    href={props.source}
-                    aria-label="download"
-                    sx={{ marginTop: 1, marginBottom: 1, verticalAlign: "middle" }}
-                >
-                    <GetAppIcon fontSize="medium" color="primary" />
-                </IconButton>
-            </Tooltip>
+            <a
+                className="nv-icon-button"
+                href={props.source}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="download"
+                title="Download data file"
+            >
+                <GetAppIcon fontSize="medium" />
+            </a>
 
             <LoadingAnimation loading={props.loading} />
             {!props.disableChoice &&
@@ -234,18 +201,16 @@ export default function HeaderPanel(props) {
                 !props.showSpikeTrains && (
                     <span>
                         Click signals (
-                        <TimelineIcon
-                            fontSize="small"
-                            style={{ verticalAlign: "sub" }}
-                        />
+                        <span className="nv-inline-icon">
+                            <TimelineIcon fontSize="small" />
+                        </span>
                         ) and/or spike trains (
-                        <ScatterPlotIcon
-                            fontSize="small"
-                            style={{ verticalAlign: "sub" }}
-                        />
+                        <span className="nv-inline-icon">
+                            <ScatterPlotIcon fontSize="small" />
+                        </span>
                         )
                     </span>
                 )}
-        </Box>
+        </div>
     );
 }

--- a/js/react/src/InfoPanel.js
+++ b/js/react/src/InfoPanel.js
@@ -1,55 +1,62 @@
-import React from 'react';
-
-import Paper from '@mui/material/Paper';
-import Popover from '@mui/material/Popover';
-import List from '@mui/material/List';
-import ListItem from '@mui/material/ListItem';
-import ListItemText from '@mui/material/ListItemText';
-
+import React from "react";
 
 function ListItemNonEmpty(props) {
     if (props.value) {
         return (
-            <ListItem>
-                <ListItemText primary={props.value} secondary={props.label} />
-            </ListItem>
-        )
+            <li className="nv-list-item">
+                <span className="nv-list-item__primary">{props.value}</span>
+                <span className="nv-list-item__secondary">{props.label}</span>
+            </li>
+        );
     } else {
-        return ""
+        return null;
     }
 }
 
-
 export default function InfoPanel(props) {
-    return (
-        <Popover
-            id={props.id}
-            open={props.open}
-            anchorEl={props.anchor}
-            onClose={props.onClose}
-            anchorOrigin={{
-                vertical: 'bottom',
-                horizontal: 'right',
-            }}
-            transformOrigin={{
-                vertical: 'top',
-                horizontal: 'center',
-            }}
-        >
-            <Paper sx={{ padding: 2 }}>
-                <List sx={{ width: '100%' }} dense={true} >
-                    <ListItemNonEmpty label="Name" value={props.info.name} />
-                    <ListItemNonEmpty label="Description" value={props.info.description} />
-                    <ListItemNonEmpty label="Recording date" value={props.info.rec_datetime} />
-                    <ListItemNonEmpty label="Source" value={props.source} />
-                    {
-                        Object.entries(props.info.annotations || {}).map(([label, value]) => {
-                            return <ListItemNonEmpty key={value} label={label} value={value} />
-                        })
-                    }
-                </List>
-            </Paper>
-        </Popover>
-    )
+    React.useEffect(() => {
+        if (!props.open) return;
 
+        const handleKeyDown = (e) => {
+            if (e.key === "Escape") props.onClose();
+        };
+
+        const handleClickOutside = (e) => {
+            const container = props.containerRef?.current;
+            if (container && !container.contains(e.target)) {
+                props.onClose();
+            }
+        };
+
+        document.addEventListener("keydown", handleKeyDown);
+        document.addEventListener("mousedown", handleClickOutside);
+        return () => {
+            document.removeEventListener("keydown", handleKeyDown);
+            document.removeEventListener("mousedown", handleClickOutside);
+        };
+    }, [props.open, props.onClose, props.containerRef]);
+
+    if (!props.open) return null;
+
+    return (
+        <div className="nv-popover" id={props.id}>
+            <ul className="nv-list">
+                <ListItemNonEmpty label="Name" value={props.info.name} />
+                <ListItemNonEmpty
+                    label="Description"
+                    value={props.info.description}
+                />
+                <ListItemNonEmpty
+                    label="Recording date"
+                    value={props.info.rec_datetime}
+                />
+                <ListItemNonEmpty label="Source" value={props.source} />
+                {Object.entries(props.info.annotations || {}).map(
+                    ([label, value]) => (
+                        <ListItemNonEmpty key={value} label={label} value={value} />
+                    )
+                )}
+            </ul>
+        </div>
+    );
 }

--- a/js/react/src/icons.js
+++ b/js/react/src/icons.js
@@ -1,0 +1,81 @@
+/**
+ * SVG icons sourced from Bootstrap Icons v1.x
+ * https://icons.getbootstrap.com/
+ * Copyright (c) 2019-2024 The Bootstrap Authors
+ * Licensed under MIT: https://github.com/twbs/icons/blob/main/LICENSE
+ */
+import React from "react";
+
+export function TimelineIcon({ style, fontSize }) {
+    // Bootstrap Icons: graph-up
+    const size = fontSize === "small" ? 20 : 24;
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width={size}
+            height={size}
+            viewBox="0 0 16 16"
+            fill="currentColor"
+            style={style}
+            aria-hidden="true"
+        >
+            <path
+                fillRule="evenodd"
+                d="M0 0h1v15h15v1H0zm14.817 3.113a.5.5 0 0 1 .07.704l-4.5 5.5a.5.5 0 0 1-.74.037L7.06 6.767l-3.656 5.027a.5.5 0 0 1-.808-.588l4-5.5a.5.5 0 0 1 .758-.06l2.609 2.61 4.15-5.073a.5.5 0 0 1 .704-.07"
+            />
+        </svg>
+    );
+}
+
+export function ScatterPlotIcon({ style, fontSize }) {
+    // Bootstrap Icons: grid-3x3-gap-fill
+    const size = fontSize === "small" ? 20 : 24;
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width={size}
+            height={size}
+            viewBox="0 0 16 16"
+            fill="currentColor"
+            style={style}
+            aria-hidden="true"
+        >
+            <path d="M1 2a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1zm5 0a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1zm5 0a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1zM1 7a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1zm5 0a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1zm5 0a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1zM1 12a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1zm5 0a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1zm5 0a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1z" />
+        </svg>
+    );
+}
+
+export function InfoIcon({ fontSize }) {
+    // Bootstrap Icons: info-circle-fill
+    const size = fontSize === "small" ? 20 : 24;
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width={size}
+            height={size}
+            viewBox="0 0 16 16"
+            fill="currentColor"
+            aria-hidden="true"
+        >
+            <path d="M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16m.93-9.412-1 4.705c-.07.34.029.533.304.533.194 0 .487-.07.686-.246l-.088.416c-.287.346-.92.598-1.465.598-.703 0-1.002-.422-.808-1.319l.738-3.468c.064-.293.006-.399-.287-.47l-.451-.081.082-.381 2.29-.287zM8 5.5a1 1 0 1 1 0-2 1 1 0 0 1 0 2" />
+        </svg>
+    );
+}
+
+export function GetAppIcon({ fontSize }) {
+    // Bootstrap Icons: download
+    const size = fontSize === "small" ? 20 : 24;
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width={size}
+            height={size}
+            viewBox="0 0 16 16"
+            fill="currentColor"
+            aria-hidden="true"
+        >
+            <path d="M.5 9.9a.5.5 0 0 1 .5.5v2.5a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-2.5a.5.5 0 0 1 1 0v2.5a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2v-2.5a.5.5 0 0 1 .5-.5" />
+            <path d="M7.646 11.854a.5.5 0 0 0 .708 0l3-3a.5.5 0 0 0-.708-.708L8.5 10.293V1.5a.5.5 0 0 0-1 0v8.793L5.354 8.146a.5.5 0 1 0-.708.708z" />
+        </svg>
+    );
+}

--- a/js/react/src/index.js
+++ b/js/react/src/index.js
@@ -1,4 +1,5 @@
 
 import Visualizer from "./Visualizer";
+import "./visualizer.css";
 
 export default Visualizer;

--- a/js/react/src/visualizer.css
+++ b/js/react/src/visualizer.css
@@ -1,0 +1,211 @@
+/* Neural Activity Visualizer — default styles */
+
+:root {
+    --nv-primary: #1976d2;
+    --nv-primary-text: #fff;
+    --nv-border-color: #bbb;
+    --nv-border-radius: 4px;
+    --nv-font-family: sans-serif;
+    --nv-font-size: 0.875rem;
+    --nv-spacing: 8px;
+    --nv-error-bg: #fdeded;
+    --nv-error-border: #f5c6cb;
+    --nv-error-color: #842029;
+    --nv-popover-bg: #fff;
+    --nv-popover-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+}
+
+/* Header layout */
+.nv-header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--nv-spacing);
+    margin: calc(var(--nv-spacing) * 2);
+    font-family: var(--nv-font-family);
+    font-size: var(--nv-font-size);
+}
+
+/* Button group */
+.nv-button-group {
+    display: inline-flex;
+    border: 1px solid var(--nv-primary);
+    border-radius: var(--nv-border-radius);
+    overflow: hidden;
+    vertical-align: middle;
+}
+
+.nv-button-group .nv-button + .nv-button {
+    border-left: 1px solid var(--nv-primary);
+}
+
+.nv-button {
+    border: none;
+    padding: 6px 12px;
+    cursor: pointer;
+    background: transparent;
+    color: var(--nv-primary);
+    font-family: var(--nv-font-family);
+    font-size: var(--nv-font-size);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.2s, color 0.2s;
+}
+
+.nv-button:hover {
+    background: rgba(25, 118, 210, 0.08);
+}
+
+.nv-button--active {
+    background: var(--nv-primary);
+    color: var(--nv-primary-text);
+}
+
+.nv-button--active:hover {
+    background: var(--nv-primary);
+    opacity: 0.9;
+}
+
+/* Icon buttons */
+.nv-icon-button {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 6px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--nv-primary);
+    border-radius: 50%;
+    transition: background 0.2s;
+    vertical-align: middle;
+    text-decoration: none;
+}
+
+.nv-icon-button:hover {
+    background: rgba(25, 118, 210, 0.08);
+}
+
+.nv-icon-button svg {
+    display: block;
+}
+
+/* Spinner */
+@keyframes nv-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.nv-spinner {
+    display: inline-block;
+    width: 24px;
+    height: 24px;
+    border: 3px solid var(--nv-border-color);
+    border-top-color: var(--nv-primary);
+    border-radius: 50%;
+    animation: nv-spin 0.8s linear infinite;
+    vertical-align: middle;
+    margin: var(--nv-spacing);
+}
+
+/* Form controls */
+.nv-form-control {
+    display: inline-flex;
+    flex-direction: column;
+    min-width: 120px;
+}
+
+.nv-label {
+    font-family: var(--nv-font-family);
+    font-size: 0.75rem;
+    color: rgba(0, 0, 0, 0.6);
+    margin-bottom: 2px;
+}
+
+.nv-select {
+    border: 1px solid var(--nv-border-color);
+    border-radius: var(--nv-border-radius);
+    padding: 6px 8px;
+    font-family: var(--nv-font-family);
+    font-size: var(--nv-font-size);
+    background: #fff;
+    cursor: pointer;
+}
+
+.nv-select:focus {
+    outline: none;
+    border-color: var(--nv-primary);
+    box-shadow: 0 0 0 2px rgba(25, 118, 210, 0.2);
+}
+
+/* Alert */
+.nv-alert {
+    padding: calc(var(--nv-spacing) * 1.5);
+    border-radius: var(--nv-border-radius);
+    font-family: var(--nv-font-family);
+    font-size: var(--nv-font-size);
+    margin: calc(var(--nv-spacing) * 2);
+}
+
+.nv-alert--error {
+    background: var(--nv-error-bg);
+    border: 1px solid var(--nv-error-border);
+    color: var(--nv-error-color);
+}
+
+/* Info container + popover */
+.nv-info-container {
+    position: relative;
+    display: inline-block;
+    vertical-align: middle;
+}
+
+.nv-popover {
+    position: absolute;
+    z-index: 1000;
+    background: var(--nv-popover-bg);
+    box-shadow: var(--nv-popover-shadow);
+    border-radius: var(--nv-border-radius);
+    padding: var(--nv-spacing);
+    min-width: 200px;
+    top: 100%;
+    left: 0;
+}
+
+/* List */
+.nv-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.nv-list-item {
+    padding: calc(var(--nv-spacing) / 2) 0;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+    display: flex;
+    flex-direction: column;
+}
+
+.nv-list-item:last-child {
+    border-bottom: none;
+}
+
+.nv-list-item__primary {
+    font-family: var(--nv-font-family);
+    font-size: var(--nv-font-size);
+    font-weight: 600;
+}
+
+.nv-list-item__secondary {
+    font-family: var(--nv-font-family);
+    font-size: 0.75rem;
+    color: rgba(0, 0, 0, 0.6);
+}
+
+/* Inline icon in hint text */
+.nv-inline-icon {
+    display: inline-flex;
+    vertical-align: sub;
+}

--- a/js/react/vite.config.js
+++ b/js/react/vite.config.js
@@ -23,8 +23,6 @@ export default defineConfig({
     },
     rollupOptions: {
       external: ['react', 'react-dom', 'react/jsx-runtime',
-        '@mui/material', '@mui/icons-material',
-        '@emotion/react', '@emotion/styled',
         'plotly.js', 'react-plotly.js'],
     },
     sourcemap: true,


### PR DESCRIPTION
Replace all MUI/Emotion components with native HTML elements and a bundled visualizer.css (with CSS custom property theming hooks), eliminating the four MUI peer dependencies and the ~200 KB overhead.

Implementation by Claude Sonnet 4.6