### PR TITLE
Changing the "source" attribute of Visualizer now updates the component.

### DIFF
--- a/js/react/src/Visualizer.js
+++ b/js/react/src/Visualizer.js
@@ -80,6 +80,12 @@ export default function Visualizer(props) {
         new DataStore(props.source, props.baseUrl || defaultBaseUrl)
     );
     React.useEffect(() => {
+        datastore.current = new DataStore(props.source, props.baseUrl || defaultBaseUrl);
+        setSignalData([]);
+        setSpikeData([]);
+        setErrorMessage("");
+        setLabels([{ label: "Segment #0", signalLabels: ["Signal #0"] }]);
+
         if (props.segmentId) {
             setSegmentId(props.segmentId);
         }
@@ -113,9 +119,25 @@ export default function Visualizer(props) {
             })
             .then((res) => {
                 setConsistent(datastore.current.isConsistentAcrossSegments(0));
+
+                const segments = datastore.current.blocks[0].segments;
+                const validSegmentId = currentSegmentId === "all" || currentSegmentId < segments.length
+                    ? currentSegmentId
+                    : 0;
+
+                const segForCheck = currentSegmentId === "all" ? 0 : validSegmentId;
+                const seg = segments[segForCheck];
+                const signals = seg.as_prop || seg.analogsignals;
+                const validSignalId = currentSignalId < signals.length
+                    ? currentSignalId
+                    : 0;
+
+                setSegmentId(validSegmentId);
+                setSignalId(validSignalId);
+
                 updateGraphData(
-                    currentSegmentId,
-                    currentSignalId,
+                    validSegmentId,
+                    validSignalId,
                     currentShowSignals,
                     currentShowSpikeTrains
                 );
@@ -132,7 +154,7 @@ export default function Visualizer(props) {
                     );
                 }
             });
-    }, []);
+    }, [props.source]);
 
     function updateGraphData(
         newSegmentId,

--- a/js/react/src/__tests__/Visualizer.test.jsx
+++ b/js/react/src/__tests__/Visualizer.test.jsx
@@ -2,30 +2,67 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import Visualizer from '../Visualizer'
 
+const { makeSegment, createMockDataStoreInstance } = vi.hoisted(() => {
+    function makeSegment(numSignals, { hasAsProp = false } = {}) {
+        const analogsignals = Array.from({ length: numSignals }, (_, i) => ({
+            name: `Signal #${i}`,
+        }))
+        const seg = { analogsignals, spiketrains: [] }
+        if (hasAsProp) {
+            seg.as_prop = analogsignals
+        }
+        return seg
+    }
+
+    function createMockDataStoreInstance(segments) {
+        return {
+            initialize: vi.fn().mockResolvedValue(undefined),
+            isConsistentAcrossSegments: vi.fn().mockReturnValue(false),
+            getLabels: vi.fn().mockReturnValue(
+                segments.map((seg, i) => ({
+                    label: `Segment #${i}`,
+                    signalLabels: seg.analogsignals.map((s) => s.name),
+                }))
+            ),
+            getSignal: vi.fn().mockResolvedValue({
+                values: [1, 2, 3],
+                times_dimensionality: 's',
+                values_units: 'mV',
+                sampling_period: 0.001,
+            }),
+            getSignalsFromAllSegments: vi.fn().mockResolvedValue([{
+                values: [1, 2, 3],
+                times_dimensionality: 's',
+                values_units: 'mV',
+                sampling_period: 0.001,
+            }]),
+            getSpikeTrains: vi.fn().mockResolvedValue([]),
+            metadata: vi.fn().mockReturnValue({}),
+            blocks: [{ segments, consistency: 'consistent' }],
+            initialized: true,
+        }
+    }
+
+    return { makeSegment, createMockDataStoreInstance }
+})
+
 // Mock DataStore
 vi.mock('../datastore', () => {
-    const MockDataStore = vi.fn().mockImplementation(() => ({
-        initialize: vi.fn().mockResolvedValue(undefined),
-        isConsistentAcrossSegments: vi.fn().mockReturnValue(false),
-        getLabels: vi.fn().mockReturnValue([
-            { label: 'Segment #0', signalLabels: ['Signal #0'] },
-        ]),
-        getSignal: vi.fn().mockResolvedValue({
-            values: [1, 2, 3],
-            times_dimensionality: 's',
-            values_units: 'mV',
-            sampling_period: 0.001,
-        }),
-        getSpikeTrains: vi.fn().mockResolvedValue([]),
-        metadata: vi.fn().mockReturnValue({}),
-        initialized: true,
-    }))
+    const MockDataStore = vi.fn().mockImplementation(() =>
+        createMockDataStoreInstance([makeSegment(2), makeSegment(2)])
+    )
     return { default: MockDataStore }
 })
 
 // Mock child panels to avoid needing full MUI + Plotly setup
 vi.mock('../HeaderPanel', () => ({
-    default: () => <div data-testid="header-panel" />,
+    default: (props) => (
+        <div
+            data-testid="header-panel"
+            data-segment-id={props.segmentId}
+            data-signal-id={props.signalId}
+        />
+    ),
 }))
 vi.mock('../GraphPanel', () => ({
     default: ({ show }) => show ? <div data-testid="graph-panel" /> : <div />,
@@ -45,7 +82,7 @@ describe('Visualizer', () => {
 
     it('shows ErrorPanel when DataStore.initialize rejects', async () => {
         const DataStore = (await import('../datastore')).default
-        DataStore.mockImplementationOnce(() => ({
+        const failingInstance = {
             initialize: vi.fn().mockRejectedValue(new Error('404 Not Found')),
             isConsistentAcrossSegments: vi.fn().mockReturnValue(false),
             getLabels: vi.fn().mockReturnValue([
@@ -53,7 +90,9 @@ describe('Visualizer', () => {
             ]),
             metadata: vi.fn().mockReturnValue({}),
             initialized: false,
-        }))
+        }
+        // Both the useRef and useEffect create a DataStore, so mock both
+        DataStore.mockImplementation(() => failingInstance)
 
         render(<Visualizer source="http://example.com/file.nwb" />)
         await waitFor(() => {
@@ -65,6 +104,168 @@ describe('Visualizer', () => {
         render(<Visualizer source="http://example.com/file.nwb" showSignals={true} />)
         await waitFor(() => {
             expect(screen.getByTestId('graph-panel')).toBeInTheDocument()
+        })
+    })
+})
+
+describe('Visualizer - dynamic source changes', () => {
+    it('reinitializes DataStore when source prop changes', async () => {
+        const DataStore = (await import('../datastore')).default
+
+        const { rerender } = render(
+            <Visualizer source="http://example.com/file1.nwb" showSignals={true} />
+        )
+        await waitFor(() => {
+            expect(screen.getByTestId('graph-panel')).toBeInTheDocument()
+        })
+
+        const callCountAfterFirst = DataStore.mock.calls.length
+
+        rerender(
+            <Visualizer source="http://example.com/file2.nwb" showSignals={true} />
+        )
+        await waitFor(() => {
+            expect(DataStore.mock.calls.length).toBeGreaterThan(callCountAfterFirst)
+        })
+
+        // Verify the new DataStore was created with the new source
+        const lastCall = DataStore.mock.calls[DataStore.mock.calls.length - 1]
+        expect(lastCall[0]).toBe('http://example.com/file2.nwb')
+    })
+
+    it('keeps segmentId and signalId when valid for the new source', async () => {
+        // Both sources have 2 segments with 2 signals each
+        const DataStore = (await import('../datastore')).default
+        DataStore.mockImplementation(() =>
+            createMockDataStoreInstance([makeSegment(2), makeSegment(2)])
+        )
+
+        const { rerender } = render(
+            <Visualizer source="http://example.com/file1.nwb" segmentId={1} signalId={1} showSignals={true} />
+        )
+        await waitFor(() => {
+            const header = screen.getByTestId('header-panel')
+            expect(header.dataset.segmentId).toBe('1')
+            expect(header.dataset.signalId).toBe('1')
+        })
+
+        rerender(
+            <Visualizer source="http://example.com/file2.nwb" segmentId={1} signalId={1} showSignals={true} />
+        )
+        await waitFor(() => {
+            const header = screen.getByTestId('header-panel')
+            expect(header.dataset.segmentId).toBe('1')
+            expect(header.dataset.signalId).toBe('1')
+        })
+    })
+
+    it('resets segmentId to 0 when invalid for the new source', async () => {
+        const DataStore = (await import('../datastore')).default
+        let callCount = 0
+        DataStore.mockImplementation(() => {
+            callCount++
+            // First source: 3 segments; second source: 1 segment
+            const segments = callCount <= 1
+                ? [makeSegment(2), makeSegment(2), makeSegment(2)]
+                : [makeSegment(2)]
+            return createMockDataStoreInstance(segments)
+        })
+
+        const { rerender } = render(
+            <Visualizer source="http://example.com/file1.nwb" segmentId={2} signalId={0} showSignals={true} />
+        )
+        await waitFor(() => {
+            const header = screen.getByTestId('header-panel')
+            expect(header.dataset.segmentId).toBe('2')
+        })
+
+        rerender(
+            <Visualizer source="http://example.com/file2.nwb" segmentId={2} signalId={0} showSignals={true} />
+        )
+        await waitFor(() => {
+            const header = screen.getByTestId('header-panel')
+            expect(header.dataset.segmentId).toBe('0')
+        })
+    })
+
+    it('resets signalId to 0 when invalid for the new source', async () => {
+        const DataStore = (await import('../datastore')).default
+        let callCount = 0
+        DataStore.mockImplementation(() => {
+            callCount++
+            // First source: 4 signals; second source: 1 signal
+            const segments = callCount <= 1
+                ? [makeSegment(4)]
+                : [makeSegment(1)]
+            return createMockDataStoreInstance(segments)
+        })
+
+        const { rerender } = render(
+            <Visualizer source="http://example.com/file1.nwb" segmentId={0} signalId={3} showSignals={true} />
+        )
+        await waitFor(() => {
+            const header = screen.getByTestId('header-panel')
+            expect(header.dataset.signalId).toBe('3')
+        })
+
+        rerender(
+            <Visualizer source="http://example.com/file2.nwb" segmentId={0} signalId={3} showSignals={true} />
+        )
+        await waitFor(() => {
+            const header = screen.getByTestId('header-panel')
+            expect(header.dataset.signalId).toBe('0')
+        })
+    })
+
+    it('validates signalId using as_prop when available', async () => {
+        const DataStore = (await import('../datastore')).default
+        let callCount = 0
+        DataStore.mockImplementation(() => {
+            callCount++
+            // First source uses as_prop with 3 signals; second source uses as_prop with 1 signal
+            const segments = callCount <= 1
+                ? [makeSegment(3, { hasAsProp: true })]
+                : [makeSegment(1, { hasAsProp: true })]
+            return createMockDataStoreInstance(segments)
+        })
+
+        const { rerender } = render(
+            <Visualizer source="http://example.com/file1.nwb" segmentId={0} signalId={2} showSignals={true} />
+        )
+        await waitFor(() => {
+            const header = screen.getByTestId('header-panel')
+            expect(header.dataset.signalId).toBe('2')
+        })
+
+        rerender(
+            <Visualizer source="http://example.com/file2.nwb" segmentId={0} signalId={2} showSignals={true} />
+        )
+        await waitFor(() => {
+            const header = screen.getByTestId('header-panel')
+            expect(header.dataset.signalId).toBe('0')
+        })
+    })
+
+    it('keeps segmentId "all" when source changes', async () => {
+        const DataStore = (await import('../datastore')).default
+        DataStore.mockImplementation(() =>
+            createMockDataStoreInstance([makeSegment(2)])
+        )
+
+        const { rerender } = render(
+            <Visualizer source="http://example.com/file1.nwb" segmentId="all" signalId={0} showSignals={true} />
+        )
+        await waitFor(() => {
+            const header = screen.getByTestId('header-panel')
+            expect(header.dataset.segmentId).toBe('all')
+        })
+
+        rerender(
+            <Visualizer source="http://example.com/file2.nwb" segmentId="all" signalId={0} showSignals={true} />
+        )
+        await waitFor(() => {
+            const header = screen.getByTestId('header-panel')
+            expect(header.dataset.segmentId).toBe('all')
         })
     })
 })


### PR DESCRIPTION
The segmentId and signalId are retained for the new source as long as they are valid; otherwise they are reset to 0.